### PR TITLE
Discard master/slave language

### DIFF
--- a/main_screen.py
+++ b/main_screen.py
@@ -52,7 +52,7 @@ SCOPES = 'https://www.googleapis.com/auth/gmail.send'
 CLIENT_SECRET_FILE = 'client_id.json'
 APPLICATION_NAME = 'Gmail API Python Send Email'
 
-temp_sensor = '/sys/bus/w1/devices/28-0000095cb34f/w1_slave'
+temp_sensor = '/sys/bus/w1/devices/28-0000095cb34f/w1_subordinate'
 
 GPIO.setmode(GPIO.BCM)
 

--- a/test_files/tempTest.py
+++ b/test_files/tempTest.py
@@ -4,7 +4,7 @@ import time
 os.system('modprobe w1-gpio')
 os.system('modprobe w1-therm')
 
-temp_sensor = '/sys/bus/w1/devices/28-0000095cb34f/w1_slave'
+temp_sensor = '/sys/bus/w1/devices/28-0000095cb34f/w1_subordinate'
 
 def read_temperature():
     f = open(temp_sensor, 'r')


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.